### PR TITLE
Use light text and take filename directly

### DIFF
--- a/src/components/home.rs
+++ b/src/components/home.rs
@@ -787,7 +787,7 @@ impl Component for Home {
         //     .borders(Borders::ALL)
         //     .border_type(BorderType::Rounded),
         // )
-        .style(Style::default().fg(Color::White)),
+        .style(Style::default()),
         // .alignment(Alignment::Center),
       rect,
     )

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ struct Args {
   #[arg(short, long, default_value_t = 5000)]
   tick_rate: u64,
 
-  #[arg(long)]
+  #[arg()]
   filename: String,
 }
 


### PR DESCRIPTION
It could be my theme, but the current White shows up as bright white text to me. 

A before/after comparison of the colors. less/lnav use this as well.

![image](https://github.com/haydenflinner/wd/assets/1449512/c32779cd-98fd-4c6e-be25-2c7784330bb5)
